### PR TITLE
fix: substr is deprecated use substring instead

### DIFF
--- a/dapp-esm.mjs
+++ b/dapp-esm.mjs
@@ -233,7 +233,7 @@ const XianWalletUtils = {
     hexToString: function(hex) {
         let bytes = [];
         for (let i = 0; i < hex.length; i += 2) {
-            bytes.push(parseInt(hex.substr(i, 2), 16));
+            bytes.push(parseInt(hex.substring(i, 2), 16));
         }
         return String.fromCharCode.apply(String, bytes);
     },


### PR DESCRIPTION
# motivation

>Deprecated: This feature is no longer recommended. Though some browsers might still support it, it may have already been removed from the relevant web standards, may be in the process of being dropped, or may only be kept for compatibility purposes. Avoid using it, and update existing code if possible; see the compatibility table at the bottom of this page to guide your decision. Be aware that this feature may cease to work at any time.

>Note: substr() is not part of the main ECMAScript specification — it's defined in Annex B: Additional ECMAScript Features for Web Browsers, which is normative optional for non-browser runtimes. Therefore, people are advised to use the standard String.prototype.substring() and String.prototype.slice() methods instead to make their code maximally cross-platform friendly. The String.prototype.substring() page has some comparisons between the three methods.

source: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr

# solution 
use `substring()`