### PR TITLE
fix: check for string before parsing

### DIFF
--- a/dapp-esm.mjs
+++ b/dapp-esm.mjs
@@ -70,7 +70,9 @@ const XianWalletUtils = {
                         let decodedData = window.atob(data);
                         let decodedOriginalTx = window.atob(original_tx);
                         let parsedData = JSON.parse(decodedData);
-                        parsedData.original_tx = JSON.parse(this.hexToString(decodedOriginalTx));
+                        if (typeof decodedOriginalTx !== "string"){
+                            parsedData.original_tx = JSON.parse(this.hexToString(decodedOriginalTx));
+                        }
                         resolver(parsedData);
                     }).catch(error => {
                         console.error('Final error after retries:', error);

--- a/dapp.js
+++ b/dapp.js
@@ -70,7 +70,9 @@ const XianWalletUtils = {
                         let decodedData = window.atob(data);
                         let decodedOriginalTx = window.atob(original_tx);
                         let parsedData = JSON.parse(decodedData);
-                        parsedData.original_tx = JSON.parse(this.hexToString(decodedOriginalTx));
+                        if (typeof decodedOriginalTx !== "string"){
+                            parsedData.original_tx = JSON.parse(this.hexToString(decodedOriginalTx));
+                        }
                         resolver(parsedData);
                     }).catch(error => {
                         console.error('Final error after retries:', error);


### PR DESCRIPTION
fixes "SyntaxError: Expected property name or '}' in JSON at position 1 (line 1 column 2) at JSON.parse (<anonymous>)".
leads to proper display of results from the xian wallet extension 